### PR TITLE
[文档][端口] 使用文档中所写的9000端口

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ git clone https://github.com/wuhan2020/wuhan2020
 pip install -r requirements.txt
 bash bootstrap
 ```
-然后就可以在`http://your-ip:5000/wuhan2020/[list_path]`调试api
-注意`list_path`是在`utils.py`中被`data.route`注册的path
+然后就可以在`http://[your-ip]:9000/wuhan2020/[list_path]`调试api
+注意`list_path`是在`utils.py`中被`data.route`注册的path,
+`your-ip`默认是127.0.0.1
 ## 项目文件说明
 
 ```
@@ -47,8 +48,9 @@ app.register_blueprint(data, url_prefix=path_prefix)
 #使用flask蓝图功能来注册http-router
 
 if __name__ == '__main__':
-    # 使用默认端口5000
-    app.run()
+    # 使用aliyun默认端口9000
+    port = os.environ.get("FC_SERVER_PORT", "9000")
+    app.run(host='127.0.0.1', port=int(port))
 ```
 ## 前端项目issues
 https://github.com/wuhan2020/front-pages/issues

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ git clone https://github.com/wuhan2020/wuhan2020
 pip install -r requirements.txt
 bash bootstrap
 ```
-然后就可以在`http://your-ip:9000/wuhan2020/`调试api
+然后就可以在`http://your-ip:5000/wuhan2020/[list_path]`调试api
+注意`list_path`是在`utils.py`中被`data.route`注册的path
 ## 项目文件说明
 
 ```
@@ -46,8 +47,8 @@ app.register_blueprint(data, url_prefix=path_prefix)
 #使用flask蓝图功能来注册http-router
 
 if __name__ == '__main__':
-    port = os.environ.get("FC_SERVER_PORT", "9000")
-    app.run(host='0.0.0.0', port=int(port))
+    # 使用默认端口5000
+    app.run()
 ```
 ## 前端项目issues
 https://github.com/wuhan2020/front-pages/issues

--- a/index.py
+++ b/index.py
@@ -7,11 +7,12 @@ app.debug = True
 path_prefix= "/wuhan2020"
 # url请求前缀，在http路径中要加/wuhan2020/
 app.register_blueprint(data, url_prefix=path_prefix)
-#使用flask蓝图功能来注册http-router
+# 使用flask蓝图功能来注册http-router
 
 
 def handler(environ, start_response):
     return app(environ, start_response)
 
 if __name__ == '__main__':
+    # 使用默认端口5000
     app.run()

--- a/index.py
+++ b/index.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask import  Flask
 from utils import data
+import os
 
 app = Flask(__name__)
 app.debug = True
@@ -14,5 +15,6 @@ def handler(environ, start_response):
     return app(environ, start_response)
 
 if __name__ == '__main__':
-    # 使用默认端口5000
-    app.run()
+    # 使用aliyun默认端口9000
+    port = os.environ.get("FC_SERVER_PORT", "9000")
+    app.run(host='127.0.0.1', port=int(port))

--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,7 @@ if platform.system()=="Linux":
 else:
     from index import app
     path_home=os.path.join(app.root_path,"wuhan2020")
+    print(path_home)
 # wuhan2020文件夹为https://github.com/wuhan2020/wuhan2020项目文件的本地clone
 # 阿里云serverless使用挂载nas远程目录来存放缓存文件；在本机调试时，缓存文件夹将存放在项目根目录
 

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,6 @@ if platform.system()=="Linux":
 else:
     from index import app
     path_home=os.path.join(app.root_path,"wuhan2020")
-    print(path_home)
 # wuhan2020文件夹为https://github.com/wuhan2020/wuhan2020项目文件的本地clone
 # 阿里云serverless使用挂载nas远程目录来存放缓存文件；在本机调试时，缓存文件夹将存放在项目根目录
 


### PR DESCRIPTION
更正了文档的开发指南写的是9000端口可以调试，实际调试中发现index.py因为没有配置端口而使用的是5000.
次pr修复了这个错误，加入9000作为默认启动端口，否则从`FC_SERVER_PORT`环境变量中读取。