### PR TITLE
[代码管理] 将https://github.com/wuhan2020/wuhan2020加入submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wuhan2020"]
+	path = wuhan2020
+	url = git@github.com:wuhan2020/wuhan2020.git


### PR DESCRIPTION
现在api-server repo 和wuhan2020 repo的data文件路径已经不同步。

解决方案：
1. 将wuhan2020作为submodule加入api-server，统一升级版本 （本PR）
2. 将wuhan2020中的文件路径作为常量写在一个file里，由api-server读取而不是手动保持同步（还未开始）