### PR TITLE
[Fix] 对wuhan2020文件夹使用相对路径 close #30

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,7 @@ from const import *
 
 data = Blueprint('register', __name__)
 if platform.system()=="Linux":
-    path_home="/home/wuhan2020/wuhan2020"
+    path_home="./wuhan2020"
 else:
     from index import app
     path_home=os.path.join(app.root_path,"wuhan2020")


### PR DESCRIPTION
在 #27 中会将wuhan2020设置为submodule，所以不将其添加进 .gitignore 。